### PR TITLE
Fix homepage text overlapping menu on small phones

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -53,6 +53,11 @@
     nav {
         background: #202030;
         font-family: 'Space Mono', monospace;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 500;
     }
 
     ul {


### PR DESCRIPTION
Changed the mobile menu from this:

![image](https://user-images.githubusercontent.com/25447795/94858342-e8f7d800-0400-11eb-893f-ce93667d368f.png)

to this:

![image](https://user-images.githubusercontent.com/25447795/94858389-f8772100-0400-11eb-8bef-0af2fb119902.png)
